### PR TITLE
Deployment error fixes, service parameters handling & installation instructions improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,5 @@ Artifacts are described in the sub-modules.
 Look for more interesting libraries here: http://maven.aksw.org/archiva/#browse/org.aksw.qa 
 
 ## Docker
-> work in progress
-### hawk
-    docker build -t hawk -f Dockerfile-hawk .
-    docker run -t hawk
 
-### hawk-fuseki
-run `cd qa.hawk/deploy-scripts && ./index_fuseki.sh` to create index
-
-    docker build -t hawk-fuseki -f Dockerfile-fuseki .
-    docker run --name hawk-fuseki -v /path/to/deploy-scripts/:/staging hawk-fuseki
-
-
-
+Follow instructions in [qa.hawk/README.md](qa.hawk/README.md)

--- a/qa.hawk/README.md
+++ b/qa.hawk/README.md
@@ -26,13 +26,12 @@ curl -X POST -d "query=What is the capital o Germany?&lang=en" http://localhost:
 
 * Before running Hawk make sure there is a Fuseki SPARQL endpoint at `http://localhost:3030/ds/query` (**RECOMMENDED**). By default, Hawk points to SPARQL endpoint at `http://131.234.28.52:3030/ds/sparql`, but you can switch to your local instance in the [application.properties](src/main/resources/application.properties).
 
-* Make sure there is an available Stanford CoreNLP server at `http://localhost:9000` (**RECOMMENDED**). Default server is `http://akswnc9.informatik.uni-leipzig.de:9000`, but you can switch to your local instance in the [application.properties](src/main/resources/application.properties).
+* Make sure there is an available Stanford CoreNLP server at `http://localhost:9000` (**RECOMMENDED**). Default server is `http://139.18.2.39:9000`, but you can switch to your local instance in the [application.properties](src/main/resources/application.properties).
 
 ### Deploying HAWK via Docker
 
-Prior deploying a HAWK instance, it needs to connect with a SPARQL endpoint. There is also a public hawk-specific SPARQL endpoint at `http://131.234.28.52:3030`.
+Prior deploying a HAWK instance, it needs to connect to a SPARQL endpoint, and interact with a Stanford CoreNLP server.
 For deploying a *containerized* SPARQL endpoint locally look at [deploy-scripts/README.md](deploy-scripts/README.md).
-
 In case you also want to intall a local *containerized* instance of Stanford CoreNLP server, run the following commands:
 
 ```bash

--- a/qa.hawk/README.md
+++ b/qa.hawk/README.md
@@ -1,53 +1,63 @@
-HAWK
-====
+# HAWK
 
 Hybrid Question Answering (hawk) -- is going to drive forth the OKBQA vision of hybrid question answering using Linked Data and full-text indizes. 
 
 Performance benchmarks can be done on the QALD-5 hybrid benchmark (test+train)
 
-The old repository can be found at https://github.com/aksw/hawk
+The old repository can be found at [https://github.com/aksw/hawk](https://github.com/aksw/hawk)
 
-Restful Service
-===
-``curl localhost:8181/search?q=What+is+the+capital+of+Germany+%3F``
-will return a UUID.
-``curl http://localhost:8181/status?UUID=00000000-0000-0000-0000-000000000001`` gives you status updates
+## Restful Service
+
+You can test Hawk features through two web service endpoints:
+
+```bash
+curl localhost:8181/simple-search?q=What+is+the+capital+of+Germany+%3F``
+```
 
 or
 
-``curl localhost:8181/simple-search?query=What+is+the+capital+of+Germany+%3F``
-
-Running HAWK
-==
-!!!Before running hawk make sure there is a SPARQL endpoint at http://localhost: or http://131.234.28.52:3030/ds/sparql!!! <br>
-!!!Make sure there is an available Stanford CoreNLP server at http://localhost: or http://akswnc9.informatik.uni-leipzig.de:9000/!!!
-
-Running HAWK via Docker
-===
-
-HAWK will connect with a SPARQL endpoint on localhost.
-There is also a public hawk-specific sparql endpoint http://131.234.28.52:3030/
-For starting our specific SPARQL endpoint locally look at deploy-scripts/README.md
-If you already have it running, you can build a hawk docker file using the following commands.
-
+```bash
+curl -X POST -d "query=What is the capital o Germany?&lang=en" http://localhost:8181/ask-gerbil
 ```
+
+## Running HAWK
+
+### Prerequisites
+
+* Before running Hawk make sure there is a Fuseki SPARQL endpoint at `http://localhost:3030/ds/query` (**RECOMMENDED**). By default, Hawk points to SPARQL endpoint at `http://131.234.28.52:3030/ds/sparql`, but you can switch to your local instance in the [application.properties](src/main/resources/application.properties).
+
+* Make sure there is an available Stanford CoreNLP server at `http://localhost:9000` (**RECOMMENDED**). Default server is `http://akswnc9.informatik.uni-leipzig.de:9000`, but you can switch to your local instance in the [application.properties](src/main/resources/application.properties).
+
+### Deploying HAWK via Docker
+
+Prior deploying a HAWK instance, it needs to connect with a SPARQL endpoint. There is also a public hawk-specific SPARQL endpoint at `http://131.234.28.52:3030`.
+For deploying a *containerized* SPARQL endpoint locally look at [deploy-scripts/README.md](deploy-scripts/README.md).
+
+In case you also want to intall a local *containerized* instance of Stanford CoreNLP server, run the following commands:
+
+```bash
+docker run -d -p 9000:9000 --name coreNLP motiz88/corenlp
+```
+
+If you already have both requirements running, you can now deploy a Hawk docker file using the following commands:
+
+```bash
 cd ..
 docker build -f qa.hawk/deploy-scripts/Dockerfile-hawk -t hawk .
 docker run -d --name hawk -p 8181:8181 --restart=always hawk
 ```
 
-Building HAWK
-===
-Using mvn package or mvn install there will be two artifacts generated (and installed) :
+### Building HAWK
 
--> hawk-(version).jar only contains hawk and can be used as a dependency for other projects.
+Using either `mvn package` or `mvn install` there will be two artifacts generated (and installed) :
 
--> hawk-(version)-bootable-with-spring.jar does not only contains hawk, but makes it runnable 
-   via spring (see Running HAWK via maven)
+* hawk-(version).jar only contains hawk and can be used as a dependency for other projects.
+
+* hawk-(version)-bootable-with-spring.jar does not only contains hawk, but makes it runnable using Spring Maven plugin.
 
 
-Running  HAWK via Maven
-===
-```
+### Running HAWK via Spring Maven plugin
+
+```bash
 mvn spring-boot:run
 ```

--- a/qa.hawk/pom.xml
+++ b/qa.hawk/pom.xml
@@ -29,7 +29,7 @@
 							<JAVA_OPTS>-Xms415m -Xmx16G -XX:MaxPermSize=1G</JAVA_OPTS>
 						</systemProperties>
 					</jvmArguments>
-					<mainClass>org.aksw.hawk.webservice.WebController</mainClass>
+					<mainClass>org.aksw.hawk.webservice.WebApplication</mainClass>
 					<layout>JAR</layout>
 				</configuration>
 				<executions>

--- a/qa.hawk/pom.xml
+++ b/qa.hawk/pom.xml
@@ -25,9 +25,7 @@
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<configuration>
 					<jvmArguments>
-						<systemProperties>
-							<JAVA_OPTS>-Xms415m -Xmx16G -XX:MaxPermSize=1G</JAVA_OPTS>
-						</systemProperties>
+						-Xms415m -Xmx16G -XX:MaxPermSize=1G
 					</jvmArguments>
 					<mainClass>org.aksw.hawk.webservice.WebApplication</mainClass>
 					<layout>JAR</layout>

--- a/qa.hawk/src/main/java/org/aksw/hawk/controller/PipelineStanford.java
+++ b/qa.hawk/src/main/java/org/aksw/hawk/controller/PipelineStanford.java
@@ -1,6 +1,7 @@
 package org.aksw.hawk.controller;
 
 import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 
 import org.aksw.hawk.datastructures.Answer;
@@ -12,6 +13,7 @@ import org.aksw.hawk.nouncombination.NounCombinationChain;
 import org.aksw.hawk.nouncombination.NounCombiners;
 import org.aksw.hawk.number.UnitController;
 import org.aksw.hawk.querybuilding.PatternSparqlGenerator;
+import org.aksw.hawk.util.PropertiesLoader;
 import org.aksw.qa.annotation.spotter.ASpotter;
 import org.aksw.qa.annotation.spotter.Fox;
 import org.aksw.qa.annotation.spotter.Spotlight;
@@ -19,7 +21,9 @@ import org.aksw.qa.commons.sparql.SPARQL;
 import org.json.simple.parser.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
 
 public class PipelineStanford extends AbstractPipeline {
 	static Logger log = LoggerFactory.getLogger(PipelineStanford.class);
@@ -34,13 +38,7 @@ public class PipelineStanford extends AbstractPipeline {
 	private UnitController numberToDigit;
 	private NounCombinationChain nounCombination;
 
-	@Value("${fuseki.sparql.endpoint.url}")
-	private String fusekiSPARQLEndpointURL;
-
-	@Value("${fuseki.sparql.endpoint.port}")
-	private String fusekiSPARQLEndpointPort;
-
-
+	private final Properties environment = PropertiesLoader.loadProperties();
 
 	public PipelineStanford() {
 		queryTypeClassifier = new QueryTypeClassifier();
@@ -61,7 +59,8 @@ public class PipelineStanford extends AbstractPipeline {
 		pruner = new MutableTreePruner();
 
 		SPARQL sparql = new SPARQL(String.format("http://%s:%s/ds/sparql",
-				this.fusekiSPARQLEndpointURL, this.fusekiSPARQLEndpointPort));
+				environment.getProperty("fuseki.sparql.endpoint.url"),
+				environment.getProperty("fuseki.sparql.endpoint.port")));
 		annotater = new Annotater(sparql);
 
 		patternsparqlgenerator = new PatternSparqlGenerator();

--- a/qa.hawk/src/main/java/org/aksw/hawk/controller/PipelineStanford.java
+++ b/qa.hawk/src/main/java/org/aksw/hawk/controller/PipelineStanford.java
@@ -19,6 +19,7 @@ import org.aksw.qa.commons.sparql.SPARQL;
 import org.json.simple.parser.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 
 public class PipelineStanford extends AbstractPipeline {
 	static Logger log = LoggerFactory.getLogger(PipelineStanford.class);
@@ -32,6 +33,14 @@ public class PipelineStanford extends AbstractPipeline {
 
 	private UnitController numberToDigit;
 	private NounCombinationChain nounCombination;
+
+	@Value("${fuseki.sparql.endpoint.url}")
+	private String fusekiSPARQLEndpointURL;
+
+	@Value("${fuseki.sparql.endpoint.port}")
+	private String fusekiSPARQLEndpointPort;
+
+
 
 	public PipelineStanford() {
 		queryTypeClassifier = new QueryTypeClassifier();
@@ -51,7 +60,8 @@ public class PipelineStanford extends AbstractPipeline {
 
 		pruner = new MutableTreePruner();
 
-		SPARQL sparql = new SPARQL("http://131.234.28.52:3030/ds/sparql");
+		SPARQL sparql = new SPARQL(String.format("http://%s:%s/ds/sparql",
+				this.fusekiSPARQLEndpointURL, this.fusekiSPARQLEndpointPort));
 		annotater = new Annotater(sparql);
 
 		patternsparqlgenerator = new PatternSparqlGenerator();

--- a/qa.hawk/src/main/java/org/aksw/hawk/controller/PipelineStanford.java
+++ b/qa.hawk/src/main/java/org/aksw/hawk/controller/PipelineStanford.java
@@ -21,9 +21,6 @@ import org.aksw.qa.commons.sparql.SPARQL;
 import org.json.simple.parser.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.env.Environment;
 
 public class PipelineStanford extends AbstractPipeline {
 	static Logger log = LoggerFactory.getLogger(PipelineStanford.class);

--- a/qa.hawk/src/main/java/org/aksw/hawk/controller/StanfordNLPConnector.java
+++ b/qa.hawk/src/main/java/org/aksw/hawk/controller/StanfordNLPConnector.java
@@ -29,7 +29,6 @@ import edu.stanford.nlp.semgraph.SemanticGraph;
 import edu.stanford.nlp.semgraph.SemanticGraphCoreAnnotations.CollapsedCCProcessedDependenciesAnnotation;
 import edu.stanford.nlp.semgraph.SemanticGraphEdge;
 import edu.stanford.nlp.util.CoreMap;
-import org.springframework.beans.factory.annotation.Value;
 
 /**
  * This class is a Connector between HAWK and StanfordNLP Usage: Either pass a

--- a/qa.hawk/src/main/java/org/aksw/hawk/controller/StanfordNLPConnector.java
+++ b/qa.hawk/src/main/java/org/aksw/hawk/controller/StanfordNLPConnector.java
@@ -12,6 +12,7 @@ import org.aksw.hawk.datastructures.HAWKQuestion;
 import org.aksw.hawk.nlp.MutableTree;
 import org.aksw.hawk.nlp.MutableTreeNode;
 import org.aksw.hawk.number.UnitController;
+import org.aksw.hawk.util.PropertiesLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,13 +51,10 @@ public class StanfordNLPConnector {
 	public static StringBuilder out = new StringBuilder();
 	private static Logger log = LoggerFactory.getLogger(StanfordNLPConnector.class);
 
-	@Value("${stanford.server.ip}")
+    private final Properties environment = PropertiesLoader.loadProperties();
+
 	private String STANFORD_IP;
-
-	@Value("${stanford.server.port}")
 	private int STANFORD_PORT;
-
-	@Value("${stanford.server.cores}")
 	private int USED_CORES;
 
 	/**
@@ -68,6 +66,10 @@ public class StanfordNLPConnector {
 	public StanfordNLPConnector(final String annotators) {
 		Properties props = new Properties();
 		props.setProperty("annotators", annotators);
+
+		STANFORD_IP = environment.getProperty("stanford.server.ip");
+		STANFORD_PORT = new Integer(environment.getProperty("stanford.server.port"));
+		USED_CORES = new Integer(environment.getProperty("stanford.server.cores"));
 		stanfordPipe = new StanfordCoreNLPClient(props, STANFORD_IP, STANFORD_PORT, USED_CORES);
 
 	}
@@ -81,6 +83,9 @@ public class StanfordNLPConnector {
 		Properties props = new Properties();
 		props.setProperty("annotators", "tokenize, ssplit, pos,lemma, ner,parse");
 
+        STANFORD_IP = environment.getProperty("stanford.server.ip");
+        STANFORD_PORT = new Integer(environment.getProperty("stanford.server.port"));
+        USED_CORES = new Integer(environment.getProperty("stanford.server.cores"));
 		stanfordPipe = new StanfordCoreNLPClient(props, STANFORD_IP, STANFORD_PORT, USED_CORES);
 	}
 

--- a/qa.hawk/src/main/java/org/aksw/hawk/controller/StanfordNLPConnector.java
+++ b/qa.hawk/src/main/java/org/aksw/hawk/controller/StanfordNLPConnector.java
@@ -28,6 +28,7 @@ import edu.stanford.nlp.semgraph.SemanticGraph;
 import edu.stanford.nlp.semgraph.SemanticGraphCoreAnnotations.CollapsedCCProcessedDependenciesAnnotation;
 import edu.stanford.nlp.semgraph.SemanticGraphEdge;
 import edu.stanford.nlp.util.CoreMap;
+import org.springframework.beans.factory.annotation.Value;
 
 /**
  * This class is a Connector between HAWK and StanfordNLP Usage: Either pass a
@@ -48,9 +49,15 @@ public class StanfordNLPConnector {
 	private Set<IndexedWord> visitedNodes;
 	public static StringBuilder out = new StringBuilder();
 	private static Logger log = LoggerFactory.getLogger(StanfordNLPConnector.class);
-	private static final String STANFORD_IP = "139.18.2.39";
-	private static final int STANFORD_PORT = 9000;
-	private static final int USED_CORES = 4;
+
+	@Value("${stanford.server.ip}")
+	private String STANFORD_IP;
+
+	@Value("${stanford.server.port}")
+	private int STANFORD_PORT;
+
+	@Value("${stanford.server.cores}")
+	private int USED_CORES;
 
 	/**
 	 * Initializes the StanfordNLP with given Annotators.Complete Annotator list
@@ -272,14 +279,6 @@ public class StanfordNLPConnector {
 			convertGraphStanford(childMutableNode, child, graph);
 		}
 
-	}
-
-	public static String getStanfordIp() {
-		return STANFORD_IP;
-	}
-
-	public static int getStanfordPort() {
-		return STANFORD_PORT;
 	}
 
 }

--- a/qa.hawk/src/main/java/org/aksw/hawk/querybuilding/PatternSparqlGenerator.java
+++ b/qa.hawk/src/main/java/org/aksw/hawk/querybuilding/PatternSparqlGenerator.java
@@ -1,11 +1,12 @@
 package org.aksw.hawk.querybuilding;
 
 import java.io.ByteArrayOutputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
+
+import org.aksw.hawk.util.PropertiesLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.aksw.gerbil.transfer.nif.Document;
 import org.aksw.gerbil.transfer.nif.Marking;
@@ -54,11 +55,7 @@ public class PatternSparqlGenerator implements ISparqlBuilder {
 	private final static String PROJ = "?proj ";
 	private final static String PROJ2 = " ?proj2 ";
 
-	@Value("${fuseki.sparql.endpoint.url}")
-	private String fusekiSPARQLEndpointURL;
-
-	@Value("${fuseki.sparql.endpoint.port}")
-	private String fusekiSPARQLEndpointPort;
+	private final Properties environment = PropertiesLoader.loadProperties();
 
 	public PatternSparqlGenerator() {
 
@@ -454,7 +451,8 @@ public class PatternSparqlGenerator implements ISparqlBuilder {
 	@Override
 	public List<Answer> build(HAWKQuestion q) throws ExecutionException, RuntimeException, ParseException {
 		SPARQL sparql = new SPARQL(String.format("http://%s:%s/ds/sparql",
-				this.fusekiSPARQLEndpointURL, this.fusekiSPARQLEndpointPort));
+				environment.getProperty("fuseki.sparql.endpoint.url"),
+				environment.getProperty("fuseki.sparql.endpoint.port")));
 		Annotater annotator = new Annotater(sparql);
 		annotator.annotateTree(q);
 		

--- a/qa.hawk/src/main/java/org/aksw/hawk/querybuilding/PatternSparqlGenerator.java
+++ b/qa.hawk/src/main/java/org/aksw/hawk/querybuilding/PatternSparqlGenerator.java
@@ -5,8 +5,6 @@ import java.util.*;
 import java.util.concurrent.ExecutionException;
 
 import org.aksw.hawk.util.PropertiesLoader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import org.aksw.gerbil.transfer.nif.Document;
 import org.aksw.gerbil.transfer.nif.Marking;
@@ -32,7 +30,6 @@ import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
 import com.google.common.collect.Lists;
-import org.springframework.beans.factory.annotation.Value;
 
 public class PatternSparqlGenerator implements ISparqlBuilder {
 

--- a/qa.hawk/src/main/java/org/aksw/hawk/querybuilding/PatternSparqlGenerator.java
+++ b/qa.hawk/src/main/java/org/aksw/hawk/querybuilding/PatternSparqlGenerator.java
@@ -31,6 +31,7 @@ import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
 import com.google.common.collect.Lists;
+import org.springframework.beans.factory.annotation.Value;
 
 public class PatternSparqlGenerator implements ISparqlBuilder {
 
@@ -52,6 +53,12 @@ public class PatternSparqlGenerator implements ISparqlBuilder {
 	private final static String URI_START_PREFIX = "http://dbpedia.org/";
 	private final static String PROJ = "?proj ";
 	private final static String PROJ2 = " ?proj2 ";
+
+	@Value("${fuseki.sparql.endpoint.url}")
+	private String fusekiSPARQLEndpointURL;
+
+	@Value("${fuseki.sparql.endpoint.port}")
+	private String fusekiSPARQLEndpointPort;
 
 	public PatternSparqlGenerator() {
 
@@ -446,7 +453,8 @@ public class PatternSparqlGenerator implements ISparqlBuilder {
 
 	@Override
 	public List<Answer> build(HAWKQuestion q) throws ExecutionException, RuntimeException, ParseException {
-		SPARQL sparql = new SPARQL("http://131.234.28.52:3030/ds/sparql");
+		SPARQL sparql = new SPARQL(String.format("http://%s:%s/ds/sparql",
+				this.fusekiSPARQLEndpointURL, this.fusekiSPARQLEndpointPort));
 		Annotater annotator = new Annotater(sparql);
 		annotator.annotateTree(q);
 		

--- a/qa.hawk/src/main/java/org/aksw/hawk/util/PropertiesLoader.java
+++ b/qa.hawk/src/main/java/org/aksw/hawk/util/PropertiesLoader.java
@@ -1,0 +1,26 @@
+package org.aksw.hawk.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class PropertiesLoader {
+
+    private static final String PROPERTIES_FILENAME = "application.properties";
+
+    public static Properties loadProperties() {
+
+        Properties configuration = new Properties();
+        try {
+
+            InputStream inputStream = PropertiesLoader.class
+                    .getClassLoader()
+                    .getResourceAsStream(PROPERTIES_FILENAME);
+            configuration.load(inputStream);
+            inputStream.close();
+        }catch(IOException e) {
+            // Should not happen
+        }
+        return configuration;
+    }
+}

--- a/qa.hawk/src/main/resources/application.properties
+++ b/qa.hawk/src/main/resources/application.properties
@@ -1,1 +1,8 @@
 server.port=8181
+
+fuseki.sparql.endpoint.url=127.0.0.1
+fuseki.sparql.endpoint.port=3030
+
+stanford.server.ip=127.0.0.1
+stanford.server.port=9000
+stanford.server.cores=4

--- a/qa.hawk/src/main/resources/application.properties
+++ b/qa.hawk/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 server.port=8181
 
-fuseki.sparql.endpoint.url=127.0.0.1
+fuseki.sparql.endpoint.url=131.234.28.52
 fuseki.sparql.endpoint.port=3030
 
-stanford.server.ip=127.0.0.1
+stanford.server.ip=139.18.2.39
 stanford.server.port=9000
 stanford.server.cores=4


### PR DESCRIPTION
This pull request includes the following changes/improvements:

1. Fixed ClassNotFoundException when deploying qa.hawk 2d19e61e670876cc1ef9037339153639efa69ce4
1. Fixed error: "Basic element 'jvmArguments' must not contain child elements" when deploying qa.hawk using Java SDK 8 26f91c8839c6686699da6f496b321dd90643ec10
1. Fuseki SPARQL endpoint and Stanford CoreNLP Server configuration parameters in application.properties ad64f63af5576c20a00a95294c16c51ee0abef8a 0c6465ea8f66b6bceb717d10c2c44eed3213a8dc 2d140ccd6a6063f8036ff560cf43fd2f3837c1d6 021d3743d4c54ff616251ccd246a8aa2f2c95517
1. Improved HAWK installation instructions for rapid deployment using Docker c74b21c8602c3824d651140027f9e15409341cf8 acfa67bd3a61baf3b86800c57369167761c64b49
