### PR TITLE
Ignoring unknown fields in QALD

### DIFF
--- a/qa.commons/src/main/java/org/aksw/qa/commons/load/json/ExtendedQALDJSONLoader.java
+++ b/qa.commons/src/main/java/org/aksw/qa/commons/load/json/ExtendedQALDJSONLoader.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -109,6 +110,7 @@ public final class ExtendedQALDJSONLoader {
 	 */
 	public static Object readJson(final InputStream in, final Class<?> type) throws JsonParseException, JsonMappingException, IOException {
 		ObjectMapper mapper = new ObjectMapper();
+		mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 		mapper.disable(MapperFeature.USE_GETTERS_AS_SETTERS);
 
 		return mapper.readValue(in, type);


### PR DESCRIPTION
Hi @RicardoUsbeck,
Is it fine if we just ignore the unknown fields in the QALD format? 

I recently faced a problem where the query results from the dbpedia endpoint introduced new fields which were not part of the 
QALD format previously. However, these newly introduce fields do not affect the existing expected functionality and can be ignored. Below is the stacktrace for the problem:

```
Caused by: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "distinct" (class org.aksw.qa.commons.load.json.EJResults), not marked as ignorable (one known property: "bindings"])
 at [Source: (FileInputStream); line: 23, column: 42] (through reference chain: org.aksw.qa.commons.load.json.QaldJson["questions"]->java.util.Vector[0]->org.aksw.qa.commons.load.json.QaldQuestionEntry["answers"]->java.util.Vector[0]->org.aksw.qa.commons.load.json.EJAnswers["results"]->org.aksw.qa.commons.load.json.EJResults["distinct"])
	at com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException.from(UnrecognizedPropertyException.java:61) ~[jackson-databind-2.9.10.5.jar:2.9.10.5]
	at com.fasterxml.jackson.databind.DeserializationContext.handleUnknownProperty(DeserializationContext.java:823) ~[jackson-databind-2.9.10.5.jar:2.9.10.5]
	at com.fasterxml.jackson.databind.deser.std.StdDeserializer.handleUnknownProperty(StdDeserializer.java:1153) ~[jackson-databind-2.9.10.5.jar:2.9.10.5]
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.handleUnknownProperty(BeanDeserializerBase.java:1589) ~[jackson-databind-2.9.10.5.jar:2.9.10.5]
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.handleUnknownVanilla(BeanDeserializerBase.java:1567) ~[jackson-databind-2.9.10.5.jar:2.9.10.5]
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:294) ~[jackson-databind-2.9.10.5.jar:2.9.10.5]
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:151) ~[jackson-databind-2.9.10.5.jar:2.9.10.5]
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:129) ~[jackson-databind-2.9.10.5.jar:2.9.10.5]
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:288) ~[jackson-databind-2.9.10.5.jar:2.9.10.5]
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:151) ~[jackson-databind-2.9.10.5.jar:2.9.10.5]
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:286) ~[jackson-databind-2.9.10.5.jar:2.9.10.5]
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:245) ~[jackson-databind-2.9.10.5.jar:2.9.10.5]
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:27) ~[jackson-databind-2.9.10.5.jar:2.9.10.5]
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:129) ~[jackson-databind-2.9.10.5.jar:2.9.10.5]
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:288) ~[jackson-databind-2.9.10.5.jar:2.9.10.5]
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:151) ~[jackson-databind-2.9.10.5.jar:2.9.10.5]
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:286) ~[jackson-databind-2.9.10.5.jar:2.9.10.5]
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:245) ~[jackson-databind-2.9.10.5.jar:2.9.10.5]
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:27) ~[jackson-databind-2.9.10.5.jar:2.9.10.5]
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:129) ~[jackson-databind-2.9.10.5.jar:2.9.10.5]
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:288) ~[jackson-databind-2.9.10.5.jar:2.9.10.5]
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:151) ~[jackson-databind-2.9.10.5.jar:2.9.10.5]
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4014) ~[jackson-databind-2.9.10.5.jar:2.9.10.5]
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3071) ~[jackson-databind-2.9.10.5.jar:2.9.10.5]
	at org.aksw.qa.commons.load.json.ExtendedQALDJSONLoader.readJson(ExtendedQALDJSONLoader.java:115) ~[commons-0.4.22.jar:0.4.22]
	at org.aksw.qa.commons.load.json.ExtendedQALDJSONLoader.readJson(ExtendedQALDJSONLoader.java:143) ~[commons-0.4.22.jar:0.4.22]
	at org.aksw.qa.commons.load.json.ExtendedQALDJSONLoader.readJson(ExtendedQALDJSONLoader.java:137) ~[commons-0.4.22.jar:0.4.22]
	at org.aksw.gerbil.dataset.impl.qald.FileBasedQALDDataset.init(FileBasedQALDDataset.java:95) ~[classes/:?]
	at org.aksw.gerbil.dataset.AbstractDatasetConfiguration.getPreparedDataset(AbstractDatasetConfiguration.java:87) ~[classes/:?]
	at org.aksw.gerbil.dataset.AbstractDatasetConfiguration.getDataset(AbstractDatasetConfiguration.java:74) ~[classes/:?]
	at org.aksw.gerbil.annotator.InstanceListBasedConfigurationImpl.loadAnnotator(InstanceListBasedConfigurationImpl.java:69) ~[classes/:?]
	at org.aksw.gerbil.annotator.InstanceListBasedConfigurationImpl.getAnnotator(InstanceListBasedConfigurationImpl.java:50) ~[classes/:?]
	... 5 more
```

What is your opinion of this?